### PR TITLE
Update the link of the GitHub Actions build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2526S2-CS2103-T11-4/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103-T11-4/tp/actions/workflows/gradle.yml)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Closes #8, Updates the README to correctly reflect the current repo's GitHub Actions build status badge.