### PR TITLE
Running help command after minimizing window causes it to remain minimized

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -86,6 +86,11 @@ public class HelpWindow extends UiPart<Stage> {
      * Focuses on the help window.
      */
     public void focus() {
+        if (getRoot().isIconified()) {
+            getRoot().setIconified(false);
+        }
+        getRoot().show();
+        getRoot().toFront();
         getRoot().requestFocus();
     }
 


### PR DESCRIPTION
Closes #55. Fixes known issue where re-running help command while help window is minimized causes it to not come back into focus.