### PR TITLE
Remove unassigned alias 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -796,14 +796,14 @@ Prerequisites for all test cases below: Launch the application with the sample d
    1. Prerequisites: Enter `sort phone` so that the list is not already in role order.
 
    2. Test case: `sort role`<br>
-      Expected: Residents are displayed in ascending role order, with assigned roles shown before unassigned
+      Expected: Residents are displayed in ascending role order, with residents whose role is `NONE` shown last
       residents: `Alex Yeoh`, `Bernice Yu`, `Charlotte Oliveiro`, `David Li`, `Irfan Ibrahim`,
       `Roy Balakrishnan`.
       <br><br>
 
 5. Sorting a filtered resident list
 
-   1. Prerequisites: Enter `find r/NONE` so that only unassigned residents are shown.
+   1. Prerequisites: Enter `find r/NONE` so that only residents whose role is `NONE` are shown.
 
    2. Test case: `sort unit`<br>
       Expected: Only the filtered residents remain displayed, sorted by unit number: `Irfan Ibrahim`,

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,10 +30,10 @@ public class FindCommand extends Command {
             + "[" + PREFIX_UNIT_NUMBER + "UNIT_NUMBER]... "
             + "[" + PREFIX_ROLE + "ROLE]...\n"
             + "Every search term must be prefixed.\n"
-            + "Role can be HA, FH, RA, or unassigned.\n"
+            + "Role can be HA, FH, RA, or NONE.\n"
             + "Examples: " + COMMAND_WORD + " n/alex n/david\n"
             + "          " + COMMAND_WORD + " n/alex p/9876 u/02-25 r/HA\n"
-            + "          " + COMMAND_WORD + " r/unassigned";
+            + "          " + COMMAND_WORD + " r/NONE";
 
     private final Predicate<Resident> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -16,7 +16,6 @@ import seedu.address.model.resident.UnitNumber;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    private static final String UNASSIGNED_ROLE_ALIAS = "UNASSIGNED";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -78,28 +77,16 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String role} into an {@code Role}.
-     * Leading and trailing whitespaces will be trimmed. The user-facing alias
-     * {@code unassigned} is mapped to {@link Role#NONE}.
+     * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code role} is invalid.
      */
     public static Role parseRole(String role) throws ParseException {
         requireNonNull(role);
-        String normalizedRole = normalizeRole(role);
+        String normalizedRole = role.trim().toUpperCase();
         if (!Role.isValidRole(normalizedRole)) {
             throw new ParseException(Role.MESSAGE_CONSTRAINTS);
         }
         return Role.valueOf(normalizedRole);
-    }
-
-    /**
-     * Normalizes accepted user-facing role aliases to the corresponding enum name.
-     */
-    private static String normalizeRole(String role) {
-        String trimmedRole = role.trim().toUpperCase();
-        if (UNASSIGNED_ROLE_ALIAS.equals(trimmedRole)) {
-            return Role.NONE.name();
-        }
-        return trimmedRole;
     }
 }

--- a/src/main/java/seedu/address/model/resident/Role.java
+++ b/src/main/java/seedu/address/model/resident/Role.java
@@ -14,7 +14,7 @@ public enum Role {
     RA("Resident Assistant", 2);
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Role should be one of HA, FH, RA, or unassigned.";
+            "Role should be one of HA, FH, RA, or NONE.";
 
     public final String role;
     private final int sortRank;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -89,11 +89,11 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_unassignedRoleAlias_returnsFindCommand() {
+    public void parse_noneRole_returnsFindCommand() {
         FindCommand expectedFindCommand = new FindCommand(new ResidentMatchesFindPredicate(
                 List.of(), List.of(), List.of(), List.of(Role.NONE)));
 
-        assertParseSuccess(parser, "r/unassigned", expectedFindCommand);
+        assertParseSuccess(parser, "r/NONE", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -143,9 +143,4 @@ public class ParserUtilTest {
         assertEquals(expectedRole, ParserUtil.parseRole(roleWithWhitespace));
     }
 
-    @Test
-    public void parseRole_unassignedAlias_returnsNoneRole() throws Exception {
-        assertEquals(Role.NONE, ParserUtil.parseRole("unassigned"));
-    }
-
 }


### PR DESCRIPTION
Closes #181 

Removes the `unassigned` alias, only `NONE` or `none` can be used for no role residents now.